### PR TITLE
Enhance portfolio with AOS animations

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+import { useEffect } from "react";
+import AOS from "aos";
+import "aos/dist/aos.css";
+
 import { Navbar } from "@/components/navbar";
 import { HeroSection } from "@/components/hero-section";
 import { About } from "@/components/about";
@@ -7,6 +13,9 @@ import { Projects } from "@/components/projects";
 import { Contact } from "@/components/contact";
 
 export default function Home() {
+  useEffect(() => {
+    AOS.init({ duration: 800, once: true });
+  }, []);
   return (
     <>
       <Navbar />

--- a/components/about.tsx
+++ b/components/about.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 export const About = () => {
   return (
     <motion.div
+      data-aos="fade-up"
       id="about"
       initial={{ opacity: 0, y: 50 }}
       animate={{ opacity: 1, y: 0 }}

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -6,6 +6,7 @@ import { FaLinkedin, FaGithub, FaEnvelope } from 'react-icons/fa';
 export const Contact = () => {
   return (
     <motion.div
+      data-aos="fade-up"
       id="contact"
       initial={{ opacity: 0, y: 50 }}
       animate={{ opacity: 1, y: 0 }}

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 export const Experience = () => {
   return (
     <motion.div
+      data-aos="fade-up"
       id="experience"
       initial={{ opacity: 0, y: 50 }}
       animate={{ opacity: 1, y: 0 }}

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -6,10 +6,14 @@ import { Typewriter } from 'react-simple-typewriter';
 
 export const HeroSection = () => {
   return (
-    <div className="relative h-screen bg-slate-950 text-white flex items-center justify-center">
+    <div
+      className="relative h-screen bg-slate-950 text-white flex items-center justify-center"
+      data-aos="fade-in"
+    >
       <video className="absolute inset-0 w-full h-full object-cover" autoPlay muted loop>
         <source src="/videos/background.mp4" type="video/mp4" />
       </video>
+      <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/30 to-black/60" />
       <div className="relative z-10 text-center flex flex-col items-center">
         <motion.h1
           initial={{ opacity: 0, y: -50 }}

--- a/components/projects.tsx
+++ b/components/projects.tsx
@@ -38,6 +38,7 @@ const projectsData = [
 export const Projects = () => {
   return (
     <motion.div
+      data-aos="fade-up"
       id="projects"
       initial={{ opacity: 0, y: 50 }}
       animate={{ opacity: 1, y: 0 }}
@@ -49,7 +50,11 @@ export const Projects = () => {
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         {projectsData.map((project, index) => (
-          <div key={index} className="bg-slate-800 p-4 rounded-lg shadow-md">
+          <div
+            key={index}
+            data-aos="zoom-in"
+            className="bg-slate-800 p-4 rounded-lg shadow-md"
+          >
             <motion.div
               whileHover={{ scale: 1.05 }}
               className="overflow-hidden rounded-lg mb-4"

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -60,6 +60,7 @@ const skillsData = [
 export const Skills = () => {
   return (
     <motion.div
+      data-aos="fade-up"
       id="skills"
       initial={{ opacity: 0, y: 50 }}
       animate={{ opacity: 1, y: 0 }}

--- a/types/aos.d.ts
+++ b/types/aos.d.ts
@@ -1,0 +1,1 @@
+declare module 'aos';


### PR DESCRIPTION
## Summary
- convert main page to a client component and init AOS
- add fade animations to each section with `data-aos`
- enhance hero section with gradient overlay and fade-in animation
- include declaration file for `aos`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f55d33fe4832286d6b1ee1cf0f816